### PR TITLE
Ensure consistency of megabyte symbols used.

### DIFF
--- a/collective/limitfilesizepanel/interfaces.py
+++ b/collective/limitfilesizepanel/interfaces.py
@@ -12,13 +12,13 @@ class ILimitFileSizePanel(Interface):
 
     file_size = schema.Int(
         title=_(u"Set the file-type size limit"),
-        description=_(u"Type here a number in Mb which will limit the file size upload"),
+        description=_(u"Type here a number in MB which will limit the file size upload"),
         default=30,
     )
 
     image_size = schema.Int(
         title=_(u"Set the image-type size limit"),
-        description=_(u"Type here a number in Mb which will limit the image size upload"),
+        description=_(u"Type here a number in MB which will limit the image size upload"),
         default=10,
     )
 

--- a/collective/limitfilesizepanel/locales/collective.limitfilesizepanel.pot
+++ b/collective/limitfilesizepanel/locales/collective.limitfilesizepanel.pot
@@ -53,11 +53,11 @@ msgid "Set the image-type size limit"
 msgstr ""
 
 #: ../interfaces.py:15
-msgid "Type here a number in Mb which will limit the file size upload"
+msgid "Type here a number in MB which will limit the file size upload"
 msgstr ""
 
 #: ../interfaces.py:21
-msgid "Type here a number in Mb which will limit the image size upload"
+msgid "Type here a number in MB which will limit the image size upload"
 msgstr ""
 
 #: ../interfaces.py:26
@@ -74,7 +74,7 @@ msgstr ""
 msgid "help_new_data_only"
 msgstr ""
 
-#. Default: "Validation failed. Uploaded data is too large: ${size}Mb (max ${max}Mb)"
+#. Default: "Validation failed. Uploaded data is too large: ${size}MB (max ${max}MB)"
 #: ../patches.py:83
 msgid "validation_error"
 msgstr ""

--- a/collective/limitfilesizepanel/locales/de/LC_MESSAGES/collective.limitfilesizepanel.po
+++ b/collective/limitfilesizepanel/locales/de/LC_MESSAGES/collective.limitfilesizepanel.po
@@ -48,11 +48,11 @@ msgid "Set the image-type size limit"
 msgstr "Grössenlimitierung für Bilder"
 
 #: ../interfaces.py:15
-msgid "Type here a number in Mb which will limit the file size upload"
+msgid "Type here a number in MB which will limit the file size upload"
 msgstr "Geben Sie die Limitierung der Dateigrösse in MB an."
 
 #: ../interfaces.py:21
-msgid "Type here a number in Mb which will limit the image size upload"
+msgid "Type here a number in MB which will limit the image size upload"
 msgstr "Geben Sie die Limitierung der Bildgrösse in MB an."
 
 #: ../interfaces.py:26
@@ -70,7 +70,7 @@ msgstr "Grössenlimitierung für Dateien und Bilder konfigurieren"
 msgid "help_new_data_only"
 msgstr "Wenn Sie diese Option deaktivieren und die Grössenlimiterung senken können Dateien und Bilder, deren Grösse grösser als die neue Limitierung ist, nicht mehr bearbeitet werden."
 
-#. Default: "Validation failed. Uploaded data is too large: ${size}Mb (max ${max}Mb)"
+#. Default: "Validation failed. Uploaded data is too large: ${size}MB (max ${max}MB)"
 #: ../patches.py:83
 msgid "validation_error"
 msgstr "Die Hochgeladenen Daten sind zu gross: ${size}MB, maxmium erlaubt: ${max}MB"

--- a/collective/limitfilesizepanel/locales/it/LC_MESSAGES/collective.limitfilesizepanel.po
+++ b/collective/limitfilesizepanel/locales/it/LC_MESSAGES/collective.limitfilesizepanel.po
@@ -50,12 +50,12 @@ msgid "Set the image-type size limit"
 msgstr "Imposta il limite per il tipo 'immagine'"
 
 #: ../interfaces.py:15
-msgid "Type here a number in Mb which will limit the file size upload"
-msgstr "Scrivi un numero in Mb per limitare le dimensioni dei file in upload"
+msgid "Type here a number in MB which will limit the file size upload"
+msgstr "Scrivi un numero in MB per limitare le dimensioni dei file in upload"
 
 #: ../interfaces.py:21
-msgid "Type here a number in Mb which will limit the image size upload"
-msgstr "Scrivi un numero in Mb per limitare le dimensioni delle immagini in upload"
+msgid "Type here a number in MB which will limit the image size upload"
+msgstr "Scrivi un numero in MB per limitare le dimensioni delle immagini in upload"
 
 #: ../interfaces.py:26
 msgid "Validate only new data"
@@ -73,8 +73,8 @@ msgstr ""
 "Tieni selezionato per validare solo i nuovi dati caricati.\n"
 "Se verrà deselezionato e le configurazioni sopra saranno ridotte, sarà possibile che gli utenti che modificheranno i contenuti non saranno in grado di salvare il form poiché il validatore sarà applicato anche ai dati già salvati."
 
-#. Default: "Validation failed. Uploaded data is too large: ${size}Mb (max ${max}Mb)"
+#. Default: "Validation failed. Uploaded data is too large: ${size}MB (max ${max}MB)"
 #: ../patches.py:83
 msgid "validation_error"
-msgstr "Validazione fallita. I dati caricati sono troppo grandi: ${size}Mb (massimo ${max}Mb)"
+msgstr "Validazione fallita. I dati caricati sono troppo grandi: ${size}MB (massimo ${max}MB)"
 

--- a/collective/limitfilesizepanel/patches.py
+++ b/collective/limitfilesizepanel/patches.py
@@ -84,7 +84,7 @@ def patched__call__(self, value, *args, **kwargs):
 
     if sizeMB > maxsize:
         msg = _('validation_error',
-                default=u"Validation failed. Uploaded data is too large: ${size}Mb (max ${max}Mb)",
+                default=u"Validation failed. Uploaded data is too large: ${size}MB (max ${max}MB)",
                 mapping={
                     'name': safe_unicode(self.name),
                     'size': safe_unicode("%.1f" % sizeMB),

--- a/collective/limitfilesizepanel/tests/test_maxsizecalc.py
+++ b/collective/limitfilesizepanel/tests/test_maxsizecalc.py
@@ -29,7 +29,7 @@ class TestMaxSizeCalc(base.MaxSizeTestCase):
         # original validator for file and image read maxsize from
         # zconf.ATFile.max_file_size at the end we have a number
         # so we pass maxsize=N.
-        # By default in the registry we have 30Mb for file and 10Mb for images
+        # By default in the registry we have 30MB for file and 10MB for images
         # and calling the validator with all the possible values, validation
         #should be done with user values
         validator = MaxSizeValidator('checkFileMaxSize', maxsize=50.0)
@@ -53,7 +53,7 @@ class TestMaxSizeCalc(base.MaxSizeTestCase):
     def test_size_from_validator_instance(self):
         # original validator for file and image read maxsize from
         # zconf.ATFile.max_file_size at the end we have a number
-        # By default in the registry we have 30Mb for file and 10Mb for images
+        # By default in the registry we have 30MB for file and 10MB for images
         validator = MaxSizeValidator('checkFileMaxSize', maxsize=50.0)
         or_file_size = self.settings.file_size
         self.settings.file_size = 0

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -6,6 +6,8 @@ Changelog
 
 - Add German translations.
   [jone]
+- Ensure consistency of megabyte symbols to be ``MB``.
+  [davidjb]
 
 
 1.1.2 (2013-03-26)


### PR DESCRIPTION
Mainly to adjust the user-visible validation messages that indicate what size limits are in place.  Previously 'Mb' was indicating sizes in megabits.
