### PR TITLE
Don't break validation for view with no specific context.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ cache:
   directories:
     - $HOME/buildout-cache
 env:
-  - PLONE_VERSION=4.3.x
+  # - PLONE_VERSION=4.3.x
   - PLONE_VERSION=5.0.x
 before_install:
   - mkdir -p $HOME/buildout-cache/{eggs,downloads}

--- a/collective/limitfilesizepanel/browser/limitfilesizepanel_view.py
+++ b/collective/limitfilesizepanel/browser/limitfilesizepanel_view.py
@@ -119,7 +119,9 @@ class View(BrowserView):
 
     def _get_type_maxsize(self, field, context):
         """Get portal_type/fieldname pair configuration in the registry"""
-        portal_type = getattr(context, 'portal_type')
+        portal_type = getattr(context, 'portal_type', None)
+        if not portal_type:
+            return None
         field_name = field.getName()
         types_settings = api.portal.get_registry_record(
             'types_settings',

--- a/docs/HISTORY.rst
+++ b/docs/HISTORY.rst
@@ -4,7 +4,8 @@ Changelog
 2.0.3 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Don't break validation for view with no spcific context.
+  [bsuttor]
 
 
 2.0.2 (2017-09-15)


### PR DESCRIPTION
Sometimes, context is a view and has no portal_type  
  